### PR TITLE
Fix DMA address truncation in gasket_coherent_buffer

### DIFF
--- a/src/gasket_core.h
+++ b/src/gasket_core.h
@@ -228,7 +228,7 @@ struct gasket_coherent_buffer {
 	u8 __iomem *virt_base;
 
 	/* Physical base address. */
-	ulong phys_base;
+	dma_addr_t phys_base;
 
 	/* Length of the mapping. */
 	ulong length_bytes;


### PR DESCRIPTION
`ulong` may not be sufficiently wide for addresses returned by the DMA
API. For example, a 32-bit platform can still have DMA addresses larger
than 32-bit. By using the correct type `dma_addr_t` we fix this
truncation.