### PR TITLE
fixup gasket-1.0 build error with mainline kerenl 5.16 (aarch64)

### DIFF
--- a/src/gasket_page_table.c
+++ b/src/gasket_page_table.c
@@ -56,6 +56,8 @@
 #include "gasket_constants.h"
 #include "gasket_core.h"
 
+MODULE_IMPORT_NS(DMA_BUF);
+
 /* Constants & utility macros */
 /* The number of pages that can be mapped into each second-level page table. */
 #define GASKET_PAGES_PER_SUBTABLE 512


### PR DESCRIPTION
error message:

DKMS make.log for gasket-1.0 for kernel 5.16.0-rc2 (aarch64)
Fri Dec 17 14:56:02 CST 2021
make: Entering directory '/usr/src/linux-headers-5.16.0-rc2'
  CC [M]  /var/lib/dkms/gasket/1.0/build/gasket_core.o
  CC [M]  /var/lib/dkms/gasket/1.0/build/gasket_ioctl.o
  CC [M]  /var/lib/dkms/gasket/1.0/build/gasket_interrupt.o
  CC [M]  /var/lib/dkms/gasket/1.0/build/gasket_page_table.o
  CC [M]  /var/lib/dkms/gasket/1.0/build/gasket_sysfs.o
  CC [M]  /var/lib/dkms/gasket/1.0/build/apex_driver.o
  LD [M]  /var/lib/dkms/gasket/1.0/build/gasket.o
  LD [M]  /var/lib/dkms/gasket/1.0/build/apex.o
  MODPOST /var/lib/dkms/gasket/1.0/build/Module.symvers
ERROR: modpost: module gasket uses symbol dma_buf_detach from namespace DMA_BUF, but does not import it.
ERROR: modpost: module gasket uses symbol dma_buf_put from namespace DMA_BUF, but does not import it.
ERROR: modpost: module gasket uses symbol dma_buf_get from namespace DMA_BUF, but does not import it.
ERROR: modpost: module gasket uses symbol dma_buf_unmap_attachment from namespace DMA_BUF, but does not import it.
ERROR: modpost: module gasket uses symbol dma_buf_map_attachment from namespace DMA_BUF, but does not import it.
ERROR: modpost: module gasket uses symbol dma_buf_attach from namespace DMA_BUF, but does not import it.
make[1]: *** [scripts/Makefile.modpost:134: /var/lib/dkms/gasket/1.0/build/Module.symvers] Error 1
make[1]: *** Deleting file '/var/lib/dkms/gasket/1.0/build/Module.symvers'
make: *** [Makefile:1761: modules] Error 2
make: Leaving directory '/usr/src/linux-headers-5.16.0-rc2'

Signed-off-by: Yan <yan-wyb@foxmail.com>