### PR TITLE
Import DMA_BUF symbol namespace for kernels >= 5.16

### DIFF
--- a/src/gasket_page_table.c
+++ b/src/gasket_page_table.c
@@ -53,6 +53,10 @@
 #include <linux/version.h>
 #include <linux/vmalloc.h>
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0)
+MODULE_IMPORT_NS(DMA_BUF);
+#endif
+
 #include "gasket_constants.h"
 #include "gasket_core.h"
 


### PR DESCRIPTION
Needed since 16b0314aa746 upstream.

Same as #3 but with backward compatibility.