### PR TITLE
Fix for Issue #14 and #15: Resolving DMA_BUF Import Error and Kernel Compatibility

### DIFF
--- a/src/gasket_page_table.c
+++ b/src/gasket_page_table.c
@@ -53,7 +53,7 @@
 #include <linux/version.h>
 #include <linux/vmalloc.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0)
+#if __has_include(<linux/dma-buf.h>)
 MODULE_IMPORT_NS(DMA_BUF);
 #endif
 


### PR DESCRIPTION
Fixes #14 and #15 by replacing the version-based check for DMA_BUF necessity. Solves incompatibility with backports in 5.1x.x (RedHat/Debian) kernels.

Tested on RHEL 9 and Fedora 38 on recent kernel versions.