### PR TITLE
Fixed eventfd_signal on kernels >= 6.8

### DIFF
--- a/src/gasket_interrupt.c
+++ b/src/gasket_interrupt.c
@@ -157,9 +157,13 @@ gasket_handle_interrupt(struct gasket_interrupt_data *interrupt_data,
 	trace_gasket_interrupt_event(interrupt_data->name, interrupt_index);
 	read_lock(&interrupt_data->eventfd_ctx_lock);
 	ctx = interrupt_data->eventfd_ctxs[interrupt_index];
-	if (ctx)
-		eventfd_signal(ctx, 1);
-	read_unlock(&interrupt_data->eventfd_ctx_lock);
+        if (ctx)
+                #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0)
+                        eventfd_signal(ctx);
+                #else
+                        eventfd_signal(ctx, 1);
+                #endif
+        read_unlock(&interrupt_data->eventfd_ctx_lock);
 
 	++(interrupt_data->interrupt_counts[interrupt_index]);
 }

--- a/src/gasket_page_table.c
+++ b/src/gasket_page_table.c
@@ -53,7 +53,7 @@
 #include <linux/version.h>
 #include <linux/vmalloc.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0)
+#if __has_include(<linux/dma-buf.h>)
 MODULE_IMPORT_NS(DMA_BUF);
 #endif
 


### PR DESCRIPTION
As already pointed out in #23 and #24 this change fixes a compilation error on kernels >= 6.8