### PR TITLE
fixed eventfd_signal for kernels >= 6.8

### DIFF
--- a/src/gasket_interrupt.c
+++ b/src/gasket_interrupt.c
@@ -157,9 +157,13 @@ gasket_handle_interrupt(struct gasket_interrupt_data *interrupt_data,
 	trace_gasket_interrupt_event(interrupt_data->name, interrupt_index);
 	read_lock(&interrupt_data->eventfd_ctx_lock);
 	ctx = interrupt_data->eventfd_ctxs[interrupt_index];
-	if (ctx)
-		eventfd_signal(ctx, 1);
-	read_unlock(&interrupt_data->eventfd_ctx_lock);
+        if (ctx)
+                #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0)
+                        eventfd_signal(ctx);
+                #else
+                        eventfd_signal(ctx, 1);
+                #endif
+        read_unlock(&interrupt_data->eventfd_ctx_lock);
 
 	++(interrupt_data->interrupt_counts[interrupt_index]);
 }


### PR DESCRIPTION
As already pointed out in #23 and #24 this change fixes a compilation error for kernels >= 6.8. Tested on Fedora 39 and 40 (kernel version 6.7.x and 6.8.x).