### PR TITLE
stop using no_llseek

### DIFF
--- a/src/gasket_core.c
+++ b/src/gasket_core.c
@@ -1373,7 +1373,9 @@ static long gasket_ioctl(struct file *filp, uint cmd, ulong arg)
 /* File operations for all Gasket devices. */
 static const struct file_operations gasket_file_ops = {
 	.owner = THIS_MODULE,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
 	.llseek = no_llseek,
+#endif
 	.mmap = gasket_mmap,
 	.open = gasket_open,
 	.release = gasket_release,


### PR DESCRIPTION
Since kernel commit 868941b ("fs: remove no_llseek"), no_llseek() is simply defined to be NULL, and a NULL llseek means seeking is unsupported.

refs:
- https://github.com/torvalds/linux/commit/cb787f4ac0c2e439ea8d7e6387b925f74576bdf8
- https://github.com/torvalds/linux/commit/868941b14441282ba08761b770fc6cad69d5bdb7

no_llseek has been hard dropped in linux-6.12