### PR TITLE
Fix build on 6.12, fix build when CONFIG_PM_SLEEP is ON

### DIFF
--- a/src/apex_driver.c
+++ b/src/apex_driver.c
@@ -1124,7 +1124,7 @@ remove_device:
 	gasket_pci_remove_device(pci_dev);
 	pci_disable_device(pci_dev);
 }
-
+#ifdef CONFIG_PM_SLEEP
 static int apex_pci_suspend(struct pci_dev *pci_dev, pm_message_t state) {
 	struct apex_dev *apex_dev = pci_get_drvdata(pci_dev);
 	struct gasket_dev *gasket_dev;
@@ -1162,7 +1162,7 @@ static int apex_pci_resume(struct pci_dev *pci_dev)
 
 	return 0;
 }
-
+#endif
 static struct gasket_driver_desc apex_desc = {
 	.name = "apex",
 	.driver_version = APEX_DRIVER_VERSION,

--- a/src/gasket_core.c
+++ b/src/gasket_core.c
@@ -1373,7 +1373,11 @@ static long gasket_ioctl(struct file *filp, uint cmd, ulong arg)
 /* File operations for all Gasket devices. */
 static const struct file_operations gasket_file_ops = {
 	.owner = THIS_MODULE,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0)
+	.llseek = NULL,
+#else
 	.llseek = no_llseek,
+#endif
 	.mmap = gasket_mmap,
 	.open = gasket_open,
 	.release = gasket_release,


### PR DESCRIPTION
no_llseek https://github.com/tbsdtv/linux_media/commit/af8890e8f6bb4c7ebe6d83f0491b7e8cd42d92ae

CONFIG_PM_SLEEP caused unused function fatal warning because it wasn't passed in the struct but still declared when CONFIG_PM_SLEEP was ON